### PR TITLE
Add Exchange Rates API

### DIFF
--- a/src/main/java/com/innobridge/ethpay/constants/HTTPConstants.java
+++ b/src/main/java/com/innobridge/ethpay/constants/HTTPConstants.java
@@ -14,9 +14,14 @@ public class HTTPConstants {
     public static final String SIGNIN_URL = "/auth/signin";
     public static final String SIGNUP_URL = "/auth/signup";
     public static final String SIGNOUT_URL = "/auth/signout";
-    public static final String REFRESH_TOKEN_URL = "/auth/refresh";
-
     public static final HttpMethod SIGNIN_METHOD = HttpMethod.POST;
+
+    public static final String REFRESH_TOKEN_URL = "/auth/refresh";
+    public static final String CONTACTS_URL = "/contacts";
+
+    public static final String EXCHANGE_URL = "/exchange";
+
+
     public static final String ACCESS_TOKEN = "access-token";
 
     public static final String ACCESS_COOKIE = "access-token";

--- a/src/main/java/com/innobridge/ethpay/controller/ContactController.java
+++ b/src/main/java/com/innobridge/ethpay/controller/ContactController.java
@@ -15,12 +15,13 @@ import org.springframework.web.server.ResponseStatusException;
 import static com.innobridge.ethpay.constants.HTTPConstants.*;
 
 @RestController
+@RequestMapping(CONTACTS_URL)
 public class ContactController {
 
     @Autowired
     private ContactService contactService;
 
-    @GetMapping("/contacts")
+    @GetMapping
     @ApiResponses(value = {
             @ApiResponse(responseCode = OK, description = "Retrieve user's list of email contacts",
                     content = @Content(mediaType = CONTENT_TYPE,
@@ -36,7 +37,7 @@ public class ContactController {
         }
     }
 
-    @PostMapping("/contacts")
+    @PostMapping
     @ApiResponses(value = {
             @ApiResponse(responseCode = CREATED, description = "Add a contact to user's list of email contacts",
                     content = @Content(mediaType = CONTENT_TYPE,
@@ -52,7 +53,7 @@ public class ContactController {
         }
     }
 
-    @DeleteMapping("/contacts")
+    @DeleteMapping
     @ApiResponses(value = {
             @ApiResponse(responseCode = OK, description = "Remove a contact to user's list of email contacts",
                     content = @Content(mediaType = CONTENT_TYPE,

--- a/src/main/java/com/innobridge/ethpay/controller/ExchangeController.java
+++ b/src/main/java/com/innobridge/ethpay/controller/ExchangeController.java
@@ -1,0 +1,75 @@
+package com.innobridge.ethpay.controller;
+
+import com.innobridge.ethpay.model.Crypto;
+import com.innobridge.ethpay.model.Currency;
+import com.innobridge.ethpay.model.Exchange;
+import com.innobridge.ethpay.service.ExchangeService;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import static com.innobridge.ethpay.constants.HTTPConstants.*;
+
+@RestController
+@RequestMapping(EXCHANGE_URL)
+public class ExchangeController {
+
+    @Autowired
+    private ExchangeService exchangeService;
+
+    @GetMapping
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = OK, description = "Retrieve exchange for a specified cryptocurrency",
+                    content = @Content(mediaType = CONTENT_TYPE,
+                            schema = @Schema(implementation = Exchange.class)))
+    })
+    public ResponseEntity<?> getExchange(@RequestParam Crypto crypto) {
+        try {
+            return ResponseEntity.ok(exchangeService.getExchange(crypto));
+        } catch (ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(e.getReason());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
+    @GetMapping("/all")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = OK, description = "Retrieves all Exchanges",
+                    content = @Content(mediaType = CONTENT_TYPE,
+                            schema = @Schema(implementation = Exchange.class)))
+    })
+    public ResponseEntity<?> getAllExchanges() {
+        try {
+            return ResponseEntity.ok(exchangeService.getAllExchanges());
+        } catch (ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(e.getReason());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
+
+    @PostMapping
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = OK, description = "Updates an Exchange",
+                    content = @Content(mediaType = CONTENT_TYPE,
+                            schema = @Schema(implementation = Exchange.class)))
+    })
+    public ResponseEntity<?> updateExchange(@RequestParam Crypto crypto, @RequestParam Currency currency, @RequestParam Double rate) {
+        try {
+            return ResponseEntity.ok(exchangeService.updateExchange(crypto, currency, rate));
+        } catch (ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(e.getReason());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/innobridge/ethpay/model/Crypto.java
+++ b/src/main/java/com/innobridge/ethpay/model/Crypto.java
@@ -1,0 +1,19 @@
+package com.innobridge.ethpay.model;
+
+public enum Crypto {
+    BITCOIN("BTC"),
+    ETHEREUM("ETH"),
+    LITECOIN("LTC"),
+    RIPPLE("XRP"),
+    DOGECOIN("DOGE");
+
+    private final String symbol;
+
+    Crypto(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+}

--- a/src/main/java/com/innobridge/ethpay/model/Currency.java
+++ b/src/main/java/com/innobridge/ethpay/model/Currency.java
@@ -1,0 +1,24 @@
+package com.innobridge.ethpay.model;
+
+public enum Currency {
+    USD("USD"),
+    EUR("EUR"),
+    GBP("GBP"),
+    JPY("JPY"),
+    AUD("AUD"),
+    CAD("CAD"),
+    CHF("CHF"),
+    CNY("CNY"),
+    SEK("SEK"),
+    NZD("NZD");
+
+    private final String symbol;
+
+    Currency(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+}

--- a/src/main/java/com/innobridge/ethpay/model/Exchange.java
+++ b/src/main/java/com/innobridge/ethpay/model/Exchange.java
@@ -1,0 +1,24 @@
+package com.innobridge.ethpay.model;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Document(collection = "exchange")
+@Data
+public class Exchange {
+    @Id
+    private String id;
+    @Indexed(unique = true)
+    private Crypto crypto;
+    private Map<Currency, Double> currencyRates;
+
+    public Exchange(Crypto crypto) {
+        this.crypto = crypto;
+        this.currencyRates = new HashMap<>();
+    }
+}

--- a/src/main/java/com/innobridge/ethpay/repository/ExchangeRepository.java
+++ b/src/main/java/com/innobridge/ethpay/repository/ExchangeRepository.java
@@ -1,0 +1,13 @@
+package com.innobridge.ethpay.repository;
+
+import com.innobridge.ethpay.model.Exchange;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.util.Optional;
+
+public interface ExchangeRepository extends MongoRepository<Exchange, String> {
+
+    @Query("{ 'crypto' : ?0 }")
+    Optional<Exchange> findByCrypto(String crypto);
+}

--- a/src/main/java/com/innobridge/ethpay/service/ExchangeService.java
+++ b/src/main/java/com/innobridge/ethpay/service/ExchangeService.java
@@ -1,0 +1,33 @@
+package com.innobridge.ethpay.service;
+
+import com.innobridge.ethpay.model.Crypto;
+import com.innobridge.ethpay.model.Currency;
+import com.innobridge.ethpay.model.Exchange;
+import com.innobridge.ethpay.repository.ExchangeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ExchangeService {
+
+    @Autowired
+    private ExchangeRepository exchangeRepository;
+
+    public Exchange getExchange(Crypto crypto) {
+        return exchangeRepository
+                .findByCrypto(crypto.name())
+                .orElse(new Exchange(crypto));
+    }
+
+    public List<Exchange> getAllExchanges() {
+        return exchangeRepository.findAll();
+    }
+
+    public Exchange updateExchange(Crypto crypto, Currency currency, Double rate) {
+        Exchange exchange = getExchange(crypto);
+        exchange.getCurrencyRates().put(currency, rate);
+        return exchangeRepository.save(exchange);
+    }
+}


### PR DESCRIPTION
## Description
Add exchange rates which is a map of a crypto and how much money it is worth in a currency.
eg
BITCOIN
CAD: 7000
USD: 8000

EUTHEUREM
JPY: 90000

Created the following apis to interact with the exchange rate service.
- GET /exchange: gets the exchange for a specify Crypto
- GET /exchange/all: gets all the exchange for all the Cryptos
- POST /exchange: provide the input(Crypto, Currency, amount), will either create an exchange rate for a crypto per currency.

## Test
![Screenshot 2024-08-15 at 9 32 09 PM](https://github.com/user-attachments/assets/a0f39e57-347f-456f-86d9-1dc9c945761d)
![Screenshot 2024-08-15 at 9 32 42 PM](https://github.com/user-attachments/assets/a3c89ea3-abb4-4ab3-9a36-f001fb85c77a)
![Screenshot 2024-08-15 at 9 35 42 PM](https://github.com/user-attachments/assets/7ae15504-6593-4f06-a6a7-882d06ec9f6b)
