### PR TITLE
Get transaction apis

### DIFF
--- a/src/main/java/com/innobridge/ethpay/controller/PaymentController.java
+++ b/src/main/java/com/innobridge/ethpay/controller/PaymentController.java
@@ -23,6 +23,20 @@ public class PaymentController {
     @Autowired
     private TransactionService transactionService;
 
+    @GetMapping("/{id}")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = OK, description = "Retrieve transaction by ID",
+                    content = @Content(mediaType = CONTENT_TYPE,
+                            schema = @Schema(implementation = TransactionResponse.class)))
+    })
+    public ResponseEntity<?> getTransactionById(@PathVariable String id) {
+        try {
+            return ResponseEntity.ok(transactionService.getTransactionById(getAuthentication().getId(), id));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
     @GetMapping
     @ApiResponses(value = {
             @ApiResponse(responseCode = OK, description = "Retrieve user's transactions",
@@ -37,17 +51,47 @@ public class PaymentController {
         }
     }
 
+    @GetMapping("/sender")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = OK, description = "Retrieve senders's transactions",
+                    content = @Content(mediaType = CONTENT_TYPE,
+                            schema = @Schema(implementation = TransactionResponse.class)))
+    })
+    public ResponseEntity<?> getSenderTransactions(@RequestParam(required = false) TransactionStatus status,
+                                                   @RequestParam(required = false) Currency currency){
+        try {
+            return ResponseEntity.ok(transactionService.getSenderTransactions(getAuthentication().getId(), status, currency));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
+    @GetMapping("/receiver")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = OK, description = "Retrieve receiver's transactions",
+                    content = @Content(mediaType = CONTENT_TYPE,
+                            schema = @Schema(implementation = TransactionResponse.class)))
+    })
+    public ResponseEntity<?> getReceiverTransactions(@RequestParam(required = false) TransactionStatus status,
+                                                     @RequestParam(required = false) Currency currency){
+        try {
+            return ResponseEntity.ok(transactionService.getReceiverTransactions(getAuthentication().getId(), status, currency));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
     @PostMapping("/create")
     @ApiResponses(value = {
             @ApiResponse(responseCode = CREATED, description = "Make Payment",
                     content = @Content(mediaType = CONTENT_TYPE,
-                            schema = @Schema(implementation = Transaction.class)))
+                            schema = @Schema(implementation = TransactionResponse.class)))
     })
     public ResponseEntity<?> makePayment(
             @RequestParam String receiverEmail,
             @RequestParam Currency sourceCurrency,
             @RequestParam Currency targetCurrency,
-            @RequestParam(required = false) Crypto substrateCrypto,
+            @RequestParam Crypto substrateCrypto,
             @RequestParam double targetAmount,
             @RequestParam(required = false) String message) {
         try {

--- a/src/main/java/com/innobridge/ethpay/controller/PaymentController.java
+++ b/src/main/java/com/innobridge/ethpay/controller/PaymentController.java
@@ -1,9 +1,6 @@
 package com.innobridge.ethpay.controller;
 
-import com.innobridge.ethpay.model.Account;
-import com.innobridge.ethpay.model.Crypto;
-import com.innobridge.ethpay.model.Currency;
-import com.innobridge.ethpay.model.Transaction;
+import com.innobridge.ethpay.model.*;
 import com.innobridge.ethpay.service.TransactionService;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,10 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
 
@@ -28,6 +22,20 @@ public class PaymentController {
 
     @Autowired
     private TransactionService transactionService;
+
+    @GetMapping
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = OK, description = "Retrieve user's transactions",
+                    content = @Content(mediaType = CONTENT_TYPE,
+                            schema = @Schema(implementation = TransactionResponse.class)))
+    })
+    public ResponseEntity<?> getTransactions(@RequestParam(required = false) TransactionStatus status) {
+        try {
+            return ResponseEntity.ok(transactionService.getTransactions(getAuthentication().getId(), status));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
 
     @PostMapping("/create")
     @ApiResponses(value = {

--- a/src/main/java/com/innobridge/ethpay/model/Transaction.java
+++ b/src/main/java/com/innobridge/ethpay/model/Transaction.java
@@ -53,4 +53,21 @@ public class Transaction {
         this.status = status;
         this.description = description;
     }
+
+    public TransactionResponse toTransactionResponse(String senderEmail, String receiverEmail) {
+        return TransactionResponse.builder()
+                .id(this.id)
+                .senderEmail(senderEmail)
+                .receiverEmail(receiverEmail)
+                .sourceCurrency(this.sourceCurrency)
+                .sourceAmount(this.sourceAmount)
+                .targetCurrency(this.targetCurrency)
+                .targetAmount(this.targetAmount)
+                .substrateCrypto(this.substrateCrypto)
+                .createdDate(this.createdDate)
+                .completedDate(this.completedDate)
+                .status(this.status)
+                .description(this.description)
+                .build();
+    }
 }

--- a/src/main/java/com/innobridge/ethpay/model/TransactionResponse.java
+++ b/src/main/java/com/innobridge/ethpay/model/TransactionResponse.java
@@ -1,0 +1,28 @@
+package com.innobridge.ethpay.model;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Unwrapped;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+@Builder
+@Data
+public class TransactionResponse {
+    public String id;
+    public String senderEmail;
+    public String receiverEmail;
+    public Currency sourceCurrency;
+    public BigDecimal sourceAmount;
+    public Currency targetCurrency;
+    public BigDecimal targetAmount;
+    @Unwrapped.Nullable
+    public Crypto substrateCrypto;
+    public Date createdDate;
+    public Date completedDate;
+    public TransactionStatus status;
+    public String description;
+}

--- a/src/main/java/com/innobridge/ethpay/repository/TransactionRepository.java
+++ b/src/main/java/com/innobridge/ethpay/repository/TransactionRepository.java
@@ -11,4 +11,19 @@ import java.util.List;
 public interface TransactionRepository extends MongoRepository<Transaction, String> {
     @Query(value = "{ 'senderId' : ?0, 'status' : ?1, 'sourceCurrency' : ?2}", sort = "{ 'createdDate' : -1 }")
     List<Transaction> findBySenderIdAndStatusAndSourceCurrency(String userId, TransactionStatus status, Currency sourceCurrency);
+
+    @Query(value = "{ '$or': [ { 'senderId': ?0 }, { 'receiverId': ?0 } ], 'status': { '$in': ?1 } }", sort = "{ 'createdDate' : -1 }")
+    List<Transaction> findBySenderIdOrReceiverIdAndStatusIn(String userId, List<TransactionStatus> statuses);
+
+    @Query(value = "{ 'senderId': ?0, 'status': { '$in': ?1 }}", sort = "{ 'createdDate' : -1 }")
+    List<Transaction> findBySenderIdAndStatusIn(String userId, List<TransactionStatus> statuses);
+
+    @Query(value = "{ 'senderId': ?0, 'status': { '$in': ?1 }, 'sourceCurrency': ?2 }", sort = "{ 'createdDate' : -1 }")
+    List<Transaction> findBySenderIdAndStatusInAndSourceCurrency(String userId, List<TransactionStatus> statuses, Currency sourceCurrency);
+
+    @Query(value = "{ 'receiverId': ?0, 'status': { '$in': ?1 }}", sort = "{ 'createdDate' : -1 }")
+    List<Transaction> findByReceiverIdAndStatusIn(String userId, List<TransactionStatus> statuses);
+
+    @Query(value = "{ 'receiverId': ?0, 'status': { '$in': ?1 }, 'sourceCurrency': ?2 }", sort = "{ 'createdDate' : -1 }")
+    List<Transaction> findByReceiverIdAndStatusInAndSourceCurrency(String userId, List<TransactionStatus> statuses, Currency sourceCurrency);
 }

--- a/src/main/java/com/innobridge/ethpay/security/JwtUtils.java
+++ b/src/main/java/com/innobridge/ethpay/security/JwtUtils.java
@@ -18,8 +18,8 @@ import static com.innobridge.ethpay.model.TokenType.REFRESH_TOKEN;
 
 @Component
 public class JwtUtils {
-    public static final ExpirationTime ACCESS_TOKEN_EXPIRATION_TIME = new ExpirationTime(0, 1, 1, 0);
-    public static final ExpirationTime REFRESH_TOKEN_EXPIRATION_TIME = new ExpirationTime(0, 5, 5, 0);
+    public static final ExpirationTime ACCESS_TOKEN_EXPIRATION_TIME = new ExpirationTime(0, 5, 1, 0);
+    public static final ExpirationTime REFRESH_TOKEN_EXPIRATION_TIME = new ExpirationTime(5, 5, 5, 0);
     public static final String TOKEN_TYPE = "token_type";
     private final SecretKey accessSigningKey;
     private final SecretKey refreshSigningKey;

--- a/src/main/java/com/innobridge/ethpay/service/UserService.java
+++ b/src/main/java/com/innobridge/ethpay/service/UserService.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -22,6 +23,10 @@ public class UserService implements UserDetailsService {
 
     public Optional<User> getById(String id) {
         return userRepository.findById(id);
+    }
+
+    public List<User> getUsersByIds(List<String> ids) {
+        return userRepository.findAllById(ids);
     }
 
     public Optional<User> getByUsername(String username) {


### PR DESCRIPTION
## Description
Added the following
- GET /transaction/{id}: get transaction by transaction id, only returns if the user is sender or receiver, otherwise throw not found exception
- GET /transaction/ : takes status as optional input, if status is present filters by status, if not then returns all transactions in which the user is the sender or receiver
- GET /transaction/sender: takes status and currency as optional input, if status is present filters by status or currency, if not then returns all transactions in which the user is the sender
- GET /transaction/receiver: takes status and currency as optional input, if status is present filters by status or currency, if not then returns all transactions in which the user is the receiver

The transaction response returned, the receiver and sender id is replaced ty receiver email and sender email.

The list of transaction response returned are sorted by most recently created.

## Test
![Screenshot 2024-08-17 at 1 44 41 PM](https://github.com/user-attachments/assets/3291a75a-7fa6-4863-95db-58f4f18c8dc5)
